### PR TITLE
New feature: MEME-AME transcription factor motif enrichment with customizable background sequences

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,19 @@ rcistarget_parameters:
     geneErnMethod: "aprox" # alternatively, exact but more computationally intense: "icistarget"
     geneErnMaxRank: 5000
 
+### MEME-AME - region-based motif enrichment analysis
+# https://www.bioconductor.org/packages/release/bioc/html/RcisTarget.html
+# resources: https://resources.aertslab.org/cistarget/
+meme_parameters:
+    genome_fasta: "resources/atacseq_pipeline/hg38/hg38.fa"
+    databases:
+        hocomocov13: "resources/db_meme/H13CORE_meme_format.meme"  # get from https://hocomoco13.autosome.org/downloads_v13; TOOD: get via zenodo
+    use_length_matched_background: True  # Set to True to use length-matched background, otherwise dinucleotide shuffled background will be used
+    ame_params:
+        method: fisher
+        scoring: avg
+        additional_options: "-evalue-report-threshold 0.05"
+
 ### Enrichment plot
 
 # tool specific column names for aggregation, plotting & summaries

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -62,6 +62,11 @@ pycistarget_db_dict = {k: v for k, v in pycistarget_db_dict.items() if v!=""}
 rcistarget_db_dict = config["rcistarget_parameters"]["databases"]
 rcistarget_db_dict = {k: v for k, v in rcistarget_db_dict.items() if v!=""}
 
+# load MEME-ame databases dictionary and keep only non-empty
+meme_ame_db_dict = config["meme_parameters"]["databases"]
+meme_ame_db_dict = {k: v for k, v in meme_ame_db_dict.items() if v!=""}
+
+
 ##### set global variables
 result_path = os.path.join(config["result_path"], module_name)
 
@@ -76,6 +81,9 @@ rule all:
         expand(os.path.join(result_path, '{background_region_set}', 'GREAT','genes.txt'), background_region_set=background_regions_dict.keys()),
         expand(os.path.join(result_path, '{region_set}', 'pycisTarget','{db}','{region_set}_{db}.csv'), region_set=regions_dict.keys(), db=pycistarget_db_dict.keys()),
         expand(os.path.join(result_path, '{region_set}', 'pycisTarget','{db}','{region_set}_{db}.png'), region_set=regions_dict.keys(), db=pycistarget_db_dict.keys()),
+        expand(os.path.join(result_path, '{region_set}', 'MEME_AME','{db}','ame.tsv'), region_set=regions_dict.keys(), db=meme_ame_db_dict.keys()),
+        # expand(os.path.join(result_path, '{region_set}', 'MEME_AME','{db}','{region_set}_{db}.png'), region_set=regions_dict.keys(), db=meme_ame_db_dict.keys()),
+        
         # gene enrichment analyses for mapped region - ORA_GSEApy
         expand(os.path.join(result_path, '{region_set}', 'ORA_GSEApy','{db}','{region_set}_{db}.csv'), region_set=regions_dict.keys(), db=database_dict.keys()),
         expand(os.path.join(result_path, '{region_set}', 'ORA_GSEApy','{db}','{region_set}_{db}.png'), region_set=regions_dict.keys(), db=database_dict.keys()),

--- a/workflow/envs/bedtools.yaml
+++ b/workflow/envs/bedtools.yaml
@@ -1,0 +1,7 @@
+name: bedtools
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bedtools
+  - python=3.9

--- a/workflow/envs/meme.yaml
+++ b/workflow/envs/meme.yaml
@@ -1,0 +1,8 @@
+name: meme
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bioconda::meme=5.0.2
+  - icu=58.2
+  - python=3.6

--- a/workflow/scripts/region_enrichment_analysis_GREAT.R
+++ b/workflow/scripts/region_enrichment_analysis_GREAT.R
@@ -27,6 +27,17 @@ if (genome=="hg19" | genome=="hg38"){
     orgdb <- "org.Mm.eg.db"
 }
 
+
+# Handle if file is empty
+if (file.info(regions_file)$size < 1){
+    # create empty file to keep track of output
+    f <- file(result_path, open = "a")
+    close(f)
+
+    # quit R session
+    quit(status = 0, save = "no")
+}
+
 # load query and background/universe region sets (e.g., consensus region set)
 regionSet_query <- import(regions_file, format = "BED")
 regionSet_background <- import(background_file, format = "BED")

--- a/workflow/scripts/region_enrichment_analysis_GREAT.R
+++ b/workflow/scripts/region_enrichment_analysis_GREAT.R
@@ -18,8 +18,8 @@ annot_terms_with_features <- function(res, df) {
     term <- df$id[i]
 
     # Check p-value thresholds
-    if (sum(("p_adjust" %in% names(df) && df$p_adjust[i] > 0.1),
-         ("p_adjust_hyper" %in% names(df) && df$p_adjust_hyper[i] > 0.1)) > 1) {
+    if (sum(("p_adjust" %in% names(df) && df$p_adjust[i] > 0.2),
+         ("p_adjust_hyper" %in% names(df) && df$p_adjust_hyper[i] > 0.2)) > 1) {
       regions[i] <- ""
       genes[i] <- ""
     } else {

--- a/workflow/scripts/region_enrichment_analysis_LOLA.R
+++ b/workflow/scripts/region_enrichment_analysis_LOLA.R
@@ -21,6 +21,16 @@ region_set <- snakemake@wildcards[["region_set"]]
 
 ### load data
 
+# Handle if file is empty
+if (file.info(query_regions)$size < 1){
+    # create empty file to keep track of output
+    f <- file(result_path, open = "a")
+    close(f)
+
+    # quit R session
+    quit(status = 0, save = "no")
+}
+
 # load query region sets
 regionSet_query <- readBed(query_regions)
 

--- a/workflow/scripts/region_gene_association_GREAT.R
+++ b/workflow/scripts/region_gene_association_GREAT.R
@@ -29,6 +29,24 @@ if (genome=="hg19" | genome=="hg38"){
     orgdb <- "org.Mm.eg.db"
 }
 
+# Handle if file is empty
+if (file.info(regions_file)$size < 1){
+    # create empty file to keep track of output
+    f <- file(gene_path, open = "a")
+    close(f)
+
+    # create empty file to keep track of output
+    f <- file(associations_plot_path, open = "a")
+    close(f)
+
+    # create empty file to keep track of output
+    f <- file(associations_table_path, open = "a")
+    close(f)
+
+    # quit R session
+    quit(status = 0, save = "no")
+}
+
 # load query region set
 regionSet_query <- import(regions_file, format = "BED")
 


### PR DESCRIPTION
Features:
- Background: default - control sequences (e.g. cell type background) matched to lengths of test sequences OR dinucleotide shuffled background of test sequences. May be better to use shuffled as default

Known bugs:
- Proper tracking: e.g. if MEME-AME gets cancelled and empty results files are generated, then snakemake doesn't restart these jobs

Not done:
- Integration into results aggregation & visualizations
