### PR TITLE
Limit GREAT region annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ The five tools LOLA, GREAT, pycisTarget, RcisTarget and GSEApy (over-representat
                 - `annotated_genes`: the genes associated to those regions for that term
              - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated.
             Supported values:
-                * 0: do not annotate GREAT terms with associated regions/genes
-                *  positive integer, for example 5: annotate that many top significant terms ranked by the configured adjusted p-value column
-                * 1: annotate all significant terms, restoring the previous behavior
+                - 0: do not annotate GREAT terms with associated regions/genes
+                -  positive integer, for example 5: annotate that many top significant terms ranked by the configured adjusted p-value column
+                - -1: annotate all significant terms, restoring the previous behavior
 
 
                 **⚠️ Warning**

--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ The five tools LOLA, GREAT, pycisTarget, RcisTarget and GSEApy (over-representat
             - in addition to the standard GREAT statistics, the workflow adds two extra columns to the result table:
                 - `regions`: the associated query regions for a term, written in BED-like coordinate form
                 - `annotated_genes`: the genes associated to those regions for that term
-             - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated: `0` disables annotation, `-1` annotates all significant terms, and the default `1` annotates only the top term
+             - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated.
+            Supported values:
+                * 0: do not annotate GREAT terms with associated regions/genes
+                *  positive integer, for example 5: annotate that many top significant terms ranked by the configured adjusted p-value column
+                * 1: annotate all significant terms, restoring the previous behavior
+
 
                 **⚠️ Warning**
                 This annotation can take a long time, substantially increase individual GREAT result file size, and may break Excel usage because Excel limits cell contents to 32,767 characters.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ The five tools LOLA, GREAT, pycisTarget, RcisTarget and GSEApy (over-representat
             - in addition to the standard GREAT statistics, the workflow adds two extra columns to the result table:
                 - `regions`: the associated query regions for a term, written in BED-like coordinate form
                 - `annotated_genes`: the genes associated to those regions for that term
-            - these two columns are filled for significant terms (according to configured adjusted p-value threshold), so that interesting hits can be traced back directly to the supporting regions and genes
+            - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated: `0` disables annotation, `-1` annotates all significant terms, and the default `1` annotates only the top term
+            - warning: this annotation can take a lot of time, greatly increase individual GREAT result file size, and break Excel usage because cells can exceed Excel's 32,767 character limit
+            - GREAT group-level aggregated result tables do not contain `regions` or `annotated_genes`; configure annotation and inspect the individual query result table when those details are needed
             - additional results from the region-gene association provided by GREAT:
                 - `genes.txt`: list of genes associated with the query regions
                 - `region_gene_associations.csv`: region-to-gene assignment table

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The five tools LOLA, GREAT, pycisTarget, RcisTarget and GSEApy (over-representat
 
 
         
-    - GREAT group-level aggregated result tables do not contain `regions` or `annotated_genes`; configure annotation and inspect the individual query result table when those details are needed
+        
             - additional results from the region-gene association provided by GREAT:
                 - `genes.txt`: list of genes associated with the query regions
                 - `region_gene_associations.csv`: region-to-gene assignment table

--- a/README.md
+++ b/README.md
@@ -141,9 +141,14 @@ The five tools LOLA, GREAT, pycisTarget, RcisTarget and GSEApy (over-representat
             - in addition to the standard GREAT statistics, the workflow adds two extra columns to the result table:
                 - `regions`: the associated query regions for a term, written in BED-like coordinate form
                 - `annotated_genes`: the genes associated to those regions for that term
-            - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated: `0` disables annotation, `-1` annotates all significant terms, and the default `1` annotates only the top term
-            - warning: this annotation can take a lot of time, greatly increase individual GREAT result file size, and break Excel usage because cells can exceed Excel's 32,767 character limit
-            - GREAT group-level aggregated result tables do not contain `regions` or `annotated_genes`; configure annotation and inspect the individual query result table when those details are needed
+             - `great_parameters:map_associated_regions` controls how many top significant terms (ranked by the configured adjusted p-value column) are annotated: `0` disables annotation, `-1` annotates all significant terms, and the default `1` annotates only the top term
+
+                **⚠️ Warning**
+                This annotation can take a long time, substantially increase individual GREAT result file size, and may break Excel usage because Excel limits cell contents to 32,767 characters.
+
+
+        
+    - GREAT group-level aggregated result tables do not contain `regions` or `annotated_genes`; configure annotation and inspect the individual query result table when those details are needed
             - additional results from the region-gene association provided by GREAT:
                 - `genes.txt`: list of genes associated with the query regions
                 - `region_gene_associations.csv`: region-to-gene assignment table

--- a/config/README.md
+++ b/config/README.md
@@ -19,5 +19,3 @@ For **region-set inputs** (`features_path` or `background_path` ending in `.bed`
 - additionally, the workflow requires at least the first **3 BED columns**: `chrom`, `start`, `end`.
 
 Set workflow-specific `resources` or command line arguments (CLI) in the workflow profile `workflow/profiles/default.config.yaml`, which supersedes global Snakemake profiles.
-
-GREAT region/gene annotation is controlled by `great_parameters:map_associated_regions`. The default `1` annotates only the top significant term; `0` disables annotation and `-1` restores the previous behavior of annotating all significant terms. This can take a lot of time, greatly increase file size, and break Excel usage because cells can exceed Excel's 32,767 character limit.

--- a/config/README.md
+++ b/config/README.md
@@ -19,3 +19,5 @@ For **region-set inputs** (`features_path` or `background_path` ending in `.bed`
 - additionally, the workflow requires at least the first **3 BED columns**: `chrom`, `start`, `end`.
 
 Set workflow-specific `resources` or command line arguments (CLI) in the workflow profile `workflow/profiles/default.config.yaml`, which supersedes global Snakemake profiles.
+
+GREAT region/gene annotation is controlled by `great_parameters:map_associated_regions`. The default `1` annotates only the top significant term; `0` disables annotation and `-1` restores the previous behavior of annotating all significant terms. This can take a lot of time, greatly increase file size, and break Excel usage because cells can exceed Excel's 32,767 character limit.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,6 +47,7 @@ great_parameters:
     basal_upstream: 5000 # used in 'basalPlusExt' mode
     basal_downstream: 1000 # used in 'basalPlusExt' mode
     extension: 1000000
+    map_associated_regions: -1 # number of top significant terms to annotate with regions/genes; 0: none, -1: all. This is slow, creates large files, and can exceed Excel's 32,767 character cell limit.
 
 ### pycisTarget - region based Transcription Factor Binding Site (TFBS) motif enrichment analysis
 # https://pycistarget.readthedocs.io/en/latest/index.html

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,7 +47,7 @@ great_parameters:
     basal_upstream: 5000 # used in 'basalPlusExt' mode
     basal_downstream: 1000 # used in 'basalPlusExt' mode
     extension: 1000000
-    map_associated_regions: 1 # number of top significant terms to annotate with regions/genes; 0: none, -1: all. This is slow, creates large files, and can exceed Excel's 32,767 character cell limit.
+    map_associated_regions: 1 # number of top significant terms to annotate with regions/genes; 0: none, -1: all, n >=1: n. This is slow, creates large files, and can exceed Excel's 32,767 character cell limit.
 
 ### pycisTarget - region based Transcription Factor Binding Site (TFBS) motif enrichment analysis
 # https://pycistarget.readthedocs.io/en/latest/index.html

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,7 +47,7 @@ great_parameters:
     basal_upstream: 5000 # used in 'basalPlusExt' mode
     basal_downstream: 1000 # used in 'basalPlusExt' mode
     extension: 1000000
-    map_associated_regions: -1 # number of top significant terms to annotate with regions/genes; 0: none, -1: all. This is slow, creates large files, and can exceed Excel's 32,767 character cell limit.
+    map_associated_regions: 1 # number of top significant terms to annotate with regions/genes; 0: none, -1: all. This is slow, creates large files, and can exceed Excel's 32,767 character cell limit.
 
 ### pycisTarget - region based Transcription Factor Binding Site (TFBS) motif enrichment analysis
 # https://pycistarget.readthedocs.io/en/latest/index.html

--- a/workflow/rules/enrichment_analysis.smk
+++ b/workflow/rules/enrichment_analysis.smk
@@ -25,6 +25,15 @@ rule region_enrichment_analysis_GREAT:
         database = os.path.join("resources", config["project_name"], module_name, "{database}.gmt"),
     output:
         result = os.path.join(result_path,'{region_set}','GREAT','{database}','{region_set}_{database}.csv'),
+    params:
+        min_gene_set_size = config["great_parameters"]["min_gene_set_size"],
+        mode = config["great_parameters"]["mode"],
+        basal_upstream = config["great_parameters"]["basal_upstream"],
+        basal_downstream = config["great_parameters"]["basal_downstream"],
+        extension = config["great_parameters"]["extension"],
+        map_associated_regions = config["great_parameters"].get("map_associated_regions", 1),
+        adjp_col = config["column_names"]["GREAT"]["adj_pvalue"],
+        adjp_th = config["adjp_th"]["GREAT"],
     threads: config.get("threads", 1)
     resources:
         mem_mb=config.get("mem", "16000"),

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -72,6 +72,10 @@ properties:
       extension:
         type: integer
         minimum: 0
+      map_associated_regions:
+        type: integer
+        minimum: -1
+        default: 1
   pycistarget_parameters:
     type: object
     additionalProperties: false

--- a/workflow/scripts/aggregate.py
+++ b/workflow/scripts/aggregate.py
@@ -45,6 +45,8 @@ if len(results_list)==0:
         
 # concatenate all results into one results dataframe
 result_df = pd.concat(results_list, axis=0)
+if tool == "GREAT":
+    result_df = result_df.drop(columns=["regions", "annotated_genes"], errors="ignore")
 
 # save all enirchment results
 result_df.to_csv(results_all_path)

--- a/workflow/scripts/region_enrichment_analysis_GREAT.R
+++ b/workflow/scripts/region_enrichment_analysis_GREAT.R
@@ -10,9 +10,18 @@ annot_terms_with_features <- function(res, df) {
   regions <- vector("character", nrow(df))
   genes <- vector("character", nrow(df))
 
-  needs_annotation <- rep(TRUE, nrow(df))
-  if ("p_adjust" %in% names(df)) {
-    needs_annotation <- needs_annotation & (is.na(df$p_adjust) | df$p_adjust <= snakemake@config[["adjp_th"]][["GREAT"]])
+  map_associated_regions <- as.integer(snakemake@params[["map_associated_regions"]])
+  adjp_col <- snakemake@params[["adjp_col"]]
+  adjp_th <- as.numeric(snakemake@params[["adjp_th"]])
+  needs_annotation <- rep(FALSE, nrow(df))
+  if (map_associated_regions != 0 && adjp_col %in% names(df)) {
+    significant <- which(!is.na(df[[adjp_col]]) & df[[adjp_col]] <= adjp_th)
+    if (map_associated_regions == -1) {
+      needs_annotation[significant] <- TRUE
+    } else if (map_associated_regions > 0 && length(significant) > 0) {
+      top_terms <- significant[order(df[[adjp_col]][significant])][seq_len(min(map_associated_regions, length(significant)))]
+      needs_annotation[top_terms] <- TRUE
+    }
   }
   
 
@@ -55,7 +64,6 @@ result_path <- snakemake@output[["result"]]
 
 # parameters
 genome <- snakemake@config[["genome"]]
-great_params <- snakemake@config[["great_parameters"]]
 cores_n <- snakemake@threads
 
 # set genome
@@ -85,11 +93,11 @@ res <- great(gr = regionSet_query,
       gene_sets = database,
       tss_source = genome, 
       biomart_dataset = NULL,
-      min_gene_set_size = great_params[["min_gene_set_size"]], #default: 5 
-      mode = great_params[["mode"]],
-      basal_upstream = great_params[["basal_upstream"]],
-      basal_downstream = great_params[["basal_downstream"]],
-      extension = great_params[["extension"]],
+      min_gene_set_size = snakemake@params[["min_gene_set_size"]], #default: 5
+      mode = snakemake@params[["mode"]],
+      basal_upstream = snakemake@params[["basal_upstream"]],
+      basal_downstream = snakemake@params[["basal_downstream"]],
+      extension = snakemake@params[["extension"]],
       extended_tss = NULL,
       background = regionSet_background, #default: NULL
       exclude = "gap",


### PR DESCRIPTION
## Control retrieval of regions with a new config parameter

Introduce the `map_associated_regions` parameter to decide the number of hits for which we retrieve regions and associated genes.
* If set to 0, no retrieval
* If set to n >=1, associated genes and regions for the top n hits accorded to adjusted p value are retrieved
* if set to -1, associated genes and regions for all significant terms according to adjusted p value threshold are retrieved

* Added great parameters as params in the enrichment rule